### PR TITLE
Be compatible with es5 projects

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es6",
+    "target": "es5",
+    "lib": ["es6", "es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,


### PR DESCRIPTION
Trnaspiling to es5 while providing libs for es6 support assures greater
range of compatibility for projects using this library.