### PR TITLE
Add options to toggle off components

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,42 @@ I should be pretty easy to use (hopefully), you can ether have a `horizontal-spl
 
 These can take 3 optional configuration values;
 
-|Key                              | Range                                                     | Does                                                                                                     |
-|---------------------------------|-----------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-|`primary-component-minsize`      | value in pixels                                           | Only allow the primary pane (either top or left) to go as small as this                                  |
-|`secondary-component-minsize`    | value in pixels                                           | Only allow the secondary pane (either bottom or right) to go as small as this                            |
-|`primary-component-initialratio` | initial value in a ratio of primary/secondary (range 0-1) | The initial size to create the primary pane (secondary will fill the remaining), this value will be over-ridden if a value is found in the local storage. |
-|`local-storage-key`              | string value used as the key                              | If this value is present, uses this key withing localstorage to remember the position of the divider bar |
+Key | Range | Does
+--- | --- | ---
+`primary-component-minsize` | value in pixels | Only allow the primary pane (either top or left) to go as small as this
+`secondary-component-minsize` | value in pixels | Only allow the secondary pane (either bottom or right) to go as small as this
+`primary-component-toggled-off` | boolean `true` or `false` (false by default) | Hide the primary component and the separator
+`secondary-component-toggled-off` | boolean `true` or `false` (false by default) | Hide the secondary component and the separator
+`secondary-component-minsize` | value in pixels | Only allow the secondary pane (either bottom or right) to go as small as this
+`primary-component-initialratio` | initial value in a ratio of primary/secondary (range 0-1) | The initial size to create the primary pane (secondary will fill the remaining), this value will be over-ridden if a value is found in the local storage.
+`local-storage-key` | string value used as the key  | If this value is present, uses this key withing localstorage to remember the position of the divider bar
 
 
 ```javascript
-<horizontal-split-pane primary-component-minsize="50" secondary-component-minsize="100" local-storage-key="split-pane" primary-component-initialratio="0.8">
+<horizontal-split-pane
+    primary-component-minsize="50"
+    secondary-component-minsize="100"
+    primary-component-toggled-off="false"
+    [secondary-component-toggled-off]="someCondition"
+    local-storage-key="split-pane"
+    primary-component-initialratio="0.8">
+
     <div class="split-pane-content-primary">
         <div class="upper">
             Upper pane
         </div>
     </div>
+
     <div class="split-pane-content-secondary">
         <div class="lower">
             Lower pane
         </div>
     </div>
+
 </horizontal-split-pane>
 
 ```
+
 
 ## Events
 

--- a/src/horizontal-split-pane.component.ts
+++ b/src/horizontal-split-pane.component.ts
@@ -22,11 +22,21 @@ import { PositionService } from './position.service'
   `],
   template: `
   <div #outer class="h-outer">
-    <div #primaryComponent class="upper-component">
+    <div
+      #primaryComponent
+      [hidden]="primaryToggledOff"
+      class="upper-component">
       <ng-content select=".split-pane-content-primary"></ng-content>
     </div>
-    <horizontal-split-separator #separator (notifyWillChangeSize)="notifyWillChangeSize($event)"></horizontal-split-separator>
-    <div #secondaryComponent class="lower-component">
+    <horizontal-split-separator
+      #separator
+      [hidden]="primaryToggledOff || secondaryToggledOff"
+      (notifyWillChangeSize)="notifyWillChangeSize($event)">
+    </horizontal-split-separator>
+    <div
+      #secondaryComponent
+      [hidden]="secondaryToggledOff"
+      class="lower-component">
       <ng-content select=".split-pane-content-secondary"></ng-content>
     </div>
   </div>

--- a/src/vertical-split-pane.component.ts
+++ b/src/vertical-split-pane.component.ts
@@ -21,11 +21,21 @@ import { PositionService } from './position.service'
   `],
   template: `
   <div #outer class="v-outer">
-    <div #primaryComponent class="left-component">
+    <div
+      #primaryComponent
+      [hidden]="primaryToggledOff"
+      class="left-component">
       <ng-content select=".split-pane-content-primary"></ng-content>
     </div>
-    <vertical-split-separator #separator (notifyWillChangeSize)="notifyWillChangeSize($event)"></vertical-split-separator>
-    <div #secondaryComponent class="right-component">
+    <vertical-split-separator
+      #separator
+      [hidden]="primaryToggledOff || secondaryToggledOff"
+      (notifyWillChangeSize)="notifyWillChangeSize($event)">
+    </vertical-split-separator>
+    <div
+      #secondaryComponent
+      [hidden]="secondaryToggledOff"
+      class="right-component">
       <ng-content select=".split-pane-content-secondary"></ng-content>
     </div>
   </div>


### PR DESCRIPTION
With the addition of the `primary-component-toggled-off` and
`secondary-component-toggled-off` properties, it's now possible to
toggle off the left or right (or top or bottom) components.

Note that attempting to toggle both of them off results in an exception
being thrown, so the user of the library should take care that it
doesn't happen.

Closes: wannabegeek/ng2-split-pane#10