### PR TITLE
Add option to specify pane separator thickness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Key | Range | Does
 --- | --- | ---
 `primary-component-minsize` | value in pixels | Only allow the primary pane (either top or left) to go as small as this
 `secondary-component-minsize` | value in pixels | Only allow the secondary pane (either bottom or right) to go as small as this
+`separator-thickness` | value in pixels (7 by default) | The thickness of the separator between the primary and secondary components
 `primary-component-toggled-off` | boolean `true` or `false` (false by default) | Hide the primary component and the separator
 `secondary-component-toggled-off` | boolean `true` or `false` (false by default) | Hide the secondary component and the separator
 `secondary-component-minsize` | value in pixels | Only allow the secondary pane (either bottom or right) to go as small as this

--- a/src/horizontal-split-pane-separator.component.ts
+++ b/src/horizontal-split-pane-separator.component.ts
@@ -1,18 +1,26 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { SplitSeparatorComponent } from './split-pane-separator.component'
 
 @Component({
   selector: 'horizontal-split-separator',
   styles: [`
     :host {
-      height: 7px;
       background-color: #fff;
       border-top: 1px solid #ddd;
       cursor: ns-resize;
+      position: relative;
     }
     :host:hover {
       background-color: #fafafa;
     }
+
+    .invisible-extension {
+      position: absolute;
+      height: 100%;
+      width: 100%;
+      min-height: 7px;
+    }
+
     .handle {
       width: 35px;
       height: 100%;
@@ -21,8 +29,26 @@ import { SplitSeparatorComponent } from './split-pane-separator.component'
     }
   `],
   template: `
+    <!-- Used to extend the 'draggable' area in case the separator is too thin,
+    so it's not too hard to drag. -->
+    <div
+      #invisibleExtension
+      [hidden]="thickness >= 7"
+      class="invisible-extension"></div>
+
     <div class="handle"></div>
-  `
+  `,
+  host: {
+    '[style.height.px]': 'thickness'
+  }
 })
-export class HorizontalSplitSeparatorComponent extends SplitSeparatorComponent {
+export class HorizontalSplitSeparatorComponent
+  extends SplitSeparatorComponent
+  implements OnInit {
+
+  ngAfterViewInit() {
+    this.invisibleExtension.nativeElement.style.top =
+      -(7 - this.thickness) / 2 + "px";
+  }
+
 }

--- a/src/horizontal-split-pane.component.ts
+++ b/src/horizontal-split-pane.component.ts
@@ -31,6 +31,7 @@ import { PositionService } from './position.service'
     <horizontal-split-separator
       #separator
       [hidden]="primaryToggledOff || secondaryToggledOff"
+      [thickness]="separatorThickness"
       (notifyWillChangeSize)="notifyWillChangeSize($event)">
     </horizontal-split-separator>
     <div
@@ -62,7 +63,8 @@ export class HorizontalSplitPaneComponent extends SplitPaneComponent {
   protected dividerPosition(size: number) {
     const sizePct = (size / this.getTotalSize()) * 100.0;
     this.primaryComponent.nativeElement.style.height = sizePct + "%";
-    this.secondaryComponent.nativeElement.style.height = "calc(" + (100 - sizePct) + "% - 8px)";
+    this.secondaryComponent.nativeElement.style.height =
+      "calc(" + (100 - sizePct) + "% - " + this.separatorThickness + "px)";
   }
 
   @HostListener('mousemove', ['$event'])

--- a/src/split-pane-separator.component.ts
+++ b/src/split-pane-separator.component.ts
@@ -1,10 +1,13 @@
-import { Component, OnInit, HostListener, EventEmitter, Output } from '@angular/core';
+import { Component, OnInit, HostListener, EventEmitter, Input, Output, ViewChild, ElementRef } from '@angular/core';
 
 @Component({
 })
 export class SplitSeparatorComponent implements OnInit {
 
+  @Input() protected thickness: number;
   @Output() private notifyWillChangeSize: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+  @ViewChild('invisibleExtension') protected invisibleExtension: ElementRef;
 
   constructor() { }
 

--- a/src/split-pane.component.ts
+++ b/src/split-pane.component.ts
@@ -15,6 +15,7 @@ export abstract class SplitPaneComponent implements OnChanges {
   @Input('primary-component-initialratio') protected initialRatio: number = 0.5;
   @Input('primary-component-minsize') protected primaryMinSize: number = 0;
   @Input('secondary-component-minsize') protected secondaryMinSize: number = 0;
+  @Input('separator-thickness') protected separatorThickness: number = 7;
   @Input('primary-component-toggled-off') protected primaryToggledOff: boolean = false;
   @Input('secondary-component-toggled-off') protected secondaryToggledOff: boolean = false;
   @Input('local-storage-key') private localStorageKey: string = null;

--- a/src/vertical-split-pane-separator.component.ts
+++ b/src/vertical-split-pane-separator.component.ts
@@ -1,11 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { SplitSeparatorComponent } from './split-pane-separator.component'
 
 @Component({
   selector: 'vertical-split-separator',
   styles: [`
     :host {
-      width: 7px;
       background-color: #fff;
       border-left: 1px solid #ddd;
       cursor: ew-resize;
@@ -13,6 +12,13 @@ import { SplitSeparatorComponent } from './split-pane-separator.component'
     }
     :host:hover {
       background-color: #fafafa;
+    }
+
+    .invisible-extension {
+      position: absolute;
+      height: 100%;
+      width: 100%;
+      min-width: 7px;
     }
 
     .handle {
@@ -24,8 +30,25 @@ import { SplitSeparatorComponent } from './split-pane-separator.component'
     }
   `],
   template: `
+    <!-- Used to extend the 'draggable' area in case the separator is too thin,
+    so it's not too hard to drag. -->
+    <div
+      #invisibleExtension
+      [hidden]="thickness >= 7"
+      class="invisible-extension"></div>
+
     <div class="handle"></div>
-  `
+  `,
+  host: {
+    '[style.width.px]': 'thickness'
+  }
 })
-export class VerticalSplitSeparatorComponent extends SplitSeparatorComponent {
+export class VerticalSplitSeparatorComponent
+  extends SplitSeparatorComponent
+  implements OnInit {
+
+  ngAfterViewInit() {
+    this.invisibleExtension.nativeElement.style.left =
+      -(7 - this.thickness) / 2 + "px";
+  }
 }

--- a/src/vertical-split-pane.component.ts
+++ b/src/vertical-split-pane.component.ts
@@ -30,6 +30,7 @@ import { PositionService } from './position.service'
     <vertical-split-separator
       #separator
       [hidden]="primaryToggledOff || secondaryToggledOff"
+      [thickness]="separatorThickness"
       (notifyWillChangeSize)="notifyWillChangeSize($event)">
     </vertical-split-separator>
     <div
@@ -60,7 +61,8 @@ export class VerticalSplitPaneComponent extends SplitPaneComponent {
   protected dividerPosition(size: number) {
     const sizePct = (size / this.getTotalSize()) * 100;
     this.primaryComponent.nativeElement.style.width = sizePct + "%";
-    this.secondaryComponent.nativeElement.style.width = "calc(" + (100 - sizePct) + "% - 8px)";
+    this.secondaryComponent.nativeElement.style.width =
+      "calc(" + (100 - sizePct) + "% - " + this.separatorThickness + "px)";
   }
 
   @HostListener('mousemove', ['$event'])


### PR DESCRIPTION
The `vertical-split-pane` and `horizontal-split-pane` components now
have a `separator-thickness` option, to be specified in pixels. The
default value is 7.

If the thickness is specified as less than 7, grabbing the separator to
resize the pane would be too difficult, so an invisible 7px thick
element is superimposed, and that helps.

Closes: wannabegeek/ng-split-pane#5