### PR TITLE
Fix for selecting text in splitted panes

### DIFF
--- a/src/horizontal-split-pane.component.ts
+++ b/src/horizontal-split-pane.component.ts
@@ -71,6 +71,5 @@ export class HorizontalSplitPaneComponent extends SplitPaneComponent {
         let coords = PositionService.offset(this.primaryComponent);
         this.applySizeChange(event.pageY - coords.top);
       }
-      return false;
     }
 }

--- a/src/vertical-split-pane.component.ts
+++ b/src/vertical-split-pane.component.ts
@@ -69,6 +69,5 @@ export class VerticalSplitPaneComponent extends SplitPaneComponent {
         let coords = PositionService.offset(this.primaryComponent);
         this.applySizeChange(event.pageX - coords.left);
       }
-      return false;
     }
 }


### PR DESCRIPTION
In recent build I could not select text within a pane.

How to reproduce: open default plunker https://plnkr.co/bxgcK29PNl9lexw6z6Ym , and try selecting any pane text using a mouse. 