### PR TITLE
Fixed mouse events not working inside of the panes

### DIFF
--- a/src/horizontal-split-pane.component.ts
+++ b/src/horizontal-split-pane.component.ts
@@ -72,7 +72,7 @@ export class HorizontalSplitPaneComponent extends SplitPaneComponent {
       if (this.isResizing) {
         let coords = PositionService.offset(this.primaryComponent);
         this.applySizeChange(event.pageY - coords.top);
+        return false;
       }
-      return false;
     }
 }

--- a/src/split-pane.component.ts
+++ b/src/split-pane.component.ts
@@ -136,7 +136,9 @@ export class SplitPaneComponent implements OnChanges {
 
   @HostListener('mouseup', ['$event'])
   onMouseup(event) {
-    this.stopResizing()
-    return false;
+    if (this.isResizing) {
+      this.stopResizing()
+      return false;
+    }
   }
 }

--- a/src/vertical-split-pane.component.ts
+++ b/src/vertical-split-pane.component.ts
@@ -70,7 +70,7 @@ export class VerticalSplitPaneComponent extends SplitPaneComponent {
       if (this.isResizing) {
         let coords = PositionService.offset(this.primaryComponent);
         this.applySizeChange(event.pageX - coords.left);
+        return false;
       }
-      return false;
     }
 }


### PR DESCRIPTION
Due to the handling of the mousemove event in the split pane compoments, mouse events such as html5 drag and drop and text selection are not working inside of the two panes.

Handling the mousemove event only when we are currently resizing the panes solves this issue.