### PR TITLE
fix #51

### DIFF
--- a/src/split-pane.component.ts
+++ b/src/split-pane.component.ts
@@ -97,7 +97,9 @@ export class SplitPaneComponent implements OnChanges {
     }
 
     this.dividerPosition(primarySize);
-    this.notifySizeDidChange.emit({'primary' : this.getPrimarySize(), 'secondary' : this.getSecondarySize()});
+    Promise.resolve().then(() => {
+        this.notifySizeDidChange.emit({'primary' : this.getPrimarySize(), 'secondary' : this.getSecondarySize()});
+    })
   }
 
   notifyWillChangeSize(resizing: boolean) {


### PR DESCRIPTION
by using a promise, the emit is delayed in a microtask.
It give the time to the  browser to set the offsetWidth, so the eventEmitter can send the good value when toggling on and off.